### PR TITLE
remove libcurl3 dependency?

### DIFF
--- a/pritunl-strongswan/PKGBUILD
+++ b/pritunl-strongswan/PKGBUILD
@@ -47,7 +47,6 @@ depends:yum=(
 )
 depends:apt=(
     "curl"
-    "libcurl3"
     "libgmp-dev"
     "libgmp3-dev"
     "net-tools"


### PR DESCRIPTION
Hey,
When trying to install pritunl-strongswan (which is a dependency for pritunl-link) in ubuntu 18.04 I'm getting:
```
The following packages have unmet dependencies:
 pritunl-strongswan : Depends: libcurl3 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

This is because curl on ubuntu 18.04 depends on libcurl4, and your package depends on curl and libcurl3.
Seeing as curl already depends on libcurl, can we just remove the libcurl3 dependency? Or is there a better way?

btw, I'm in love with all your work on pritunl and pritunl-zero. Although the documentation is a bit sparse. Luckily I can figure almost everything out because it's open source. Anyway, just wanted to say thanks as well.